### PR TITLE
Add Linux support (AppImage + deb)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,10 +74,36 @@ jobs:
           EP_PRE_RELEASE: false
           EP_DRAFT: true
 
-  # Only now does the release become visible to updaters, with mac and
-  # Windows assets both present.
+  # Linux needs no signing; the AppImage is the auto-update target for
+  # electron-updater, the .deb is a plain install.
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-
+      - run: npm ci
+      - run: npm run build
+      - run: npx electron-builder --linux --publish always
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          EP_PRE_RELEASE: false
+          EP_DRAFT: true
+
+  # Only now does the release become visible to updaters, with mac,
+  # Windows and Linux assets all present.
   publish:
-    needs: [build-mac, build-windows]
+    needs: [build-mac, build-windows, build-linux]
     runs-on: ubuntu-latest
     steps:
       - name: Verify both platforms uploaded, then publish
@@ -88,7 +114,7 @@ jobs:
           assets=$(gh release view "$TAG" --repo flowtricks/stacki-releases \
             --json assets --jq '[.assets[].name] | join(" ")')
           echo "assets: $assets"
-          for required in latest-mac.yml latest.yml; do
+          for required in latest-mac.yml latest.yml latest-linux.yml; do
             case " $assets " in
               *" $required "*) ;;
               *) echo "missing $required — refusing to publish"; exit 1 ;;

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Visual Builder for Astro.
 
-A Mac & Windows desktop app for editing [Astro](https://astro.build) projects visually.
+A Mac, Windows & Linux desktop app for editing [Astro](https://astro.build) projects visually.
 
 MIT licensed — fork it, build on it, ship your own version.
 
@@ -40,10 +40,13 @@ needs no Apple Developer account and no certificates:
 ```bash
 npm run dist:mac:unsigned   # .dmg + .zip, no signing (build on macOS)
 npm run dist:win            # NSIS installer (build on Windows)
+npm run dist:linux          # AppImage + .deb (build on Linux)
 ```
 
 Output lands in `release/`. macOS will warn the first time you open an
 unsigned build; right-click the app and choose Open to get past Gatekeeper.
+On Ubuntu 24.04+ the AppImage needs libfuse2 to run
+(`sudo apt install libfuse2t64`); the .deb does not.
 
 The signed variants are for maintainers with the release certificates:
 
@@ -55,10 +58,11 @@ npm run dist:mac   # requires a Developer ID cert + notarization credentials
 
 Official builds are published by CI, not from anyone's laptop. Pushing a
 `v*` tag runs `.github/workflows/release.yml`, which builds a signed and
-notarized macOS universal build plus a Windows installer, uploads them to
-the `stacki-releases` repo, and only makes the release visible once both
-platforms have landed. Shipped apps auto-update from that feed via
-`electron-updater`.
+notarized macOS universal build, a Windows installer, and Linux
+AppImage/.deb packages, uploads them to the `stacki-releases` repo, and
+only makes the release visible once all platforms have landed. Shipped
+apps auto-update from that feed via `electron-updater` (on Linux
+auto-update applies to the AppImage only, not the .deb).
 
 Signing and notarization credentials live in GitHub Actions secrets. They
 are never in this repository, and GitHub does not expose them to workflows

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",
     "dist:win": "npm run build && electron-builder --win",
+    "dist:linux": "npm run build && electron-builder --linux",
     "dist:mac:unsigned": "npm run build && electron-builder --mac -c.mac.forceCodeSigning=false -c.mac.notarize=false -c.mac.identity=null"
   },
   "dependencies": {
@@ -98,6 +99,24 @@
     "nsis": {
       "oneClick": false,
       "allowToChangeInstallationDirectory": true
+    },
+    "linux": {
+      "icon": "resources/icon.png",
+      "category": "Development",
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "deb",
+          "arch": [
+            "x64"
+          ]
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Adds Linux as a build and release target.

## What's in here

- **`package.json`** — a `dist:linux` script and a `build.linux` config (AppImage + .deb, x64), reusing the existing `resources/icon.png`. No code changes were needed: `electron/main.js` already handles non-macOS correctly (`titleBarStyle: 'default'`, PNG window icon), and there are no native Node modules.
- **`.github/workflows/release.yml`** — a `build-linux` job mirroring the mac/win jobs (nothing to sign on Linux), uploading into the same draft release. The publish gate now also requires `latest-linux.yml` before flipping the release visible.
- **README** — Linux mentioned in the intro, packaging and releases sections, including the libfuse2 note for AppImage on Ubuntu 24.04+ and the caveat that electron-updater only auto-updates the AppImage, not the .deb.

## Tested

- Built locally on Ubuntu 24.04 x64: `npm run dist:linux -- --publish never` produces a working AppImage (112 MB) and .deb (77 MB).
- Verified the app launches, creates its window, and the auto-update check handles a missing `latest-linux.yml` as an expected condition (no error dialog), so existing releases without Linux assets are harmless to Linux users.
- The `build-linux` CI job was exercised on a fork branch (same steps, `--publish never` + artifact upload) and passed: https://github.com/Laurens-HanzeLink/stacki/actions/runs/30614161747

🤖 Generated with [Claude Code](https://claude.com/claude-code)