### PR TITLE
Ask git for its answers in the language the code reads them in

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -697,7 +697,24 @@ function run(cmd, args, cwd, opts = {}) {
   // after the first call (memoized).
   ensureToolPath();
   return new Promise((resolve, reject) => {
-    execFile(cmd, args, { cwd, timeout: opts.timeout || 60000, ...opts }, (err, stdout, stderr) => {
+    const options = { cwd, timeout: opts.timeout || 60000, ...opts };
+    // git is translated, and this app reads what git says.
+    //
+    // gitBranches.js recognises a refusal by its words — "would be overwritten",
+    // "not fully merged" — and turns each one into a sentence that says what to
+    // do, or into the question the UI asks instead. On a French machine git
+    // answers "Veuillez valider ou remiser vos modifications", none of those
+    // patterns match, and the whole layer falls through to the raw porcelain it
+    // exists to replace: no offer to park the changes, no "force?" on an
+    // unmerged branch. Nothing appears broken — the app just quietly stops
+    // being helpful in every language but one.
+    //
+    // So the answers arrive in the language the code reads. LC_ALL wins over
+    // LANG and LC_MESSAGES both, which is the point: whatever the user's shell
+    // is set to, this one call is not subject to it. Only the messages are
+    // affected — paths and commit text are bytes git passes through either way.
+    options.env = { ...(opts.env || process.env), LC_ALL: 'C' };
+    execFile(cmd, args, options, (err, stdout, stderr) => {
       if (err) {
         err.stdout = stdout;
         err.stderr = stderr;

--- a/test/git-branches.js
+++ b/test/git-branches.js
@@ -31,9 +31,12 @@ const check = (what, condition, detail) => {
 
 // The runner the module takes, without main.js's PATH repair — nothing here
 // runs from a packaged app.
+// LC_ALL as main.js's runner sets it: git is translated, and both this test and
+// the code it exercises read git's words. Without it the suite passes or fails
+// by the locale of whoever runs it.
 const git = (cwd, args) =>
   new Promise((resolve, reject) => {
-    execFile('git', args, { cwd }, (err, stdout, stderr) => {
+    execFile('git', args, { cwd, env: { ...process.env, LC_ALL: 'C' } }, (err, stdout, stderr) => {
       if (err) {
         err.stdout = stdout;
         err.stderr = stderr;
@@ -622,6 +625,21 @@ const caught = async (fn) => {
     check(
       'with the work in progress on it',
       fs.readFileSync(path.join(dir, 'a.txt'), 'utf8') === 'started something\n'
+    );
+  }
+
+  // Everything above runs git under LC_ALL=C, the way the app does. That makes
+  // the suite locale-proof and, in the same move, blind to the app losing it:
+  // strip the env from main.js's runner and every check here still passes while
+  // a French machine gets none of this module's sentences. So the runner itself
+  // is read, and the one line that guarantees the rest is asserted directly.
+  {
+    const mainSrc = fs.readFileSync(path.join(__dirname, '..', 'electron', 'main.js'), 'utf8');
+    const runner = mainSrc.slice(mainSrc.indexOf('function run(cmd, args, cwd'));
+    check(
+      "main.js runs git in the language this module's patterns are written in",
+      /LC_ALL:\s*'C'/.test(runner.slice(0, runner.indexOf('\n}'))),
+      'run() no longer forces a locale — git will answer in the user’s language'
     );
   }
 

--- a/test/git-history.js
+++ b/test/git-history.js
@@ -32,9 +32,12 @@ const check = (what, condition, detail) => {
   if (!condition) failures.push(`  ${what}${detail ? `\n    ${detail}` : ''}`);
 };
 
+// LC_ALL as main.js's runner sets it: git is translated, and both this test and
+// the code it exercises read git's words. Without it the suite passes or fails
+// by the locale of whoever runs it.
 const git = (cwd, args) =>
   new Promise((resolve, reject) => {
-    execFile('git', args, { cwd, maxBuffer: 1 << 24 }, (err, stdout, stderr) => {
+    execFile('git', args, { cwd, maxBuffer: 1 << 24, env: { ...process.env, LC_ALL: 'C' } }, (err, stdout, stderr) => {
       if (err) {
         err.stdout = stdout;
         err.stderr = stderr;

--- a/test/git-snapshot.js
+++ b/test/git-snapshot.js
@@ -30,9 +30,12 @@ const check = (what, condition, detail) => {
   if (!condition) failures.push(`  ${what}${detail ? `\n    ${detail}` : ''}`);
 };
 
+// LC_ALL as main.js's runner sets it: git is translated, and both this test and
+// the code it exercises read git's words. Without it the suite passes or fails
+// by the locale of whoever runs it.
 const git = (cwd, args) =>
   new Promise((resolve, reject) => {
-    execFile('git', args, { cwd }, (err, stdout, stderr) => {
+    execFile('git', args, { cwd, env: { ...process.env, LC_ALL: 'C' } }, (err, stdout, stderr) => {
       if (err) {
         err.stdout = stdout;
         err.stderr = stderr;

--- a/test/preview-worktree.js
+++ b/test/preview-worktree.js
@@ -34,9 +34,12 @@ const check = (what, condition, detail) => {
   if (!condition) failures.push(`  ${what}${detail ? `\n    ${detail}` : ''}`);
 };
 
+// LC_ALL as main.js's runner sets it: git is translated, and both this test and
+// the code it exercises read git's words. Without it the suite passes or fails
+// by the locale of whoever runs it.
 const git = (cwd, args) =>
   new Promise((resolve, reject) => {
-    execFile('git', args, { cwd }, (err, stdout, stderr) => {
+    execFile('git', args, { cwd, env: { ...process.env, LC_ALL: 'C' } }, (err, stdout, stderr) => {
       if (err) {
         err.stdout = stdout;
         err.stderr = stderr;


### PR DESCRIPTION
`gitBranches.js` recognises a refusal by its words — `would be overwritten`, `not fully merged`, `Please commit your changes` — and turns each into a sentence saying what to do next, or into the question the UI asks instead of an error. That is the module's whole job, and it is written against English.

git is translated. On a French machine the refusal arrives as *"Veuillez valider ou remiser vos modifications avant la fusion"*, no pattern matches, and the layer falls through to the raw porcelain it exists to replace:

- merging with a dirty tree no longer offers to park the work
- deleting an unmerged branch never asks whether to force it

Nothing looks broken. The app just stops being helpful in every language but one.

### The fix

`run()` in `main.js` sets `LC_ALL=C` for the commands it reads. It is the single funnel every `git` and `gh` call goes through — the other `execFile` sites in that file run the Astro CLI and `node --version`. `LC_ALL` wins over `LANG` and `LC_MESSAGES` both, which is the point: the user's shell does not get a vote in what the app can parse. Only messages are affected; paths and commit text are bytes git passes through either way.

### The tests had the same bug

`test/git-branches.js` and `test/git-history.js` failed outright on a localised machine — they assert on the same English refusals. Forcing the locale in their own runners fixes that, but would have made them pass while staying blind to the app losing it.

So they do both: they force it, **and** they read `main.js`'s runner back. Removing that one line now fails a named check instead of failing a country.

```
$ git-branches: 108 passed
# with the LC_ALL line removed from main.js:
$ git-branches: 1 of 108 failed
    main.js runs git in the language this module's patterns are written in
      run() no longer forces a locale — git will answer in the user's language
```

### Verification

Full suite green: 54 test files, including `git-branches: 108`, `git-history: 75`, `git-snapshot: 35`, `preview-worktree: 25`, `conflicts: 64`.

Found while running `npm test` on a French macOS, where those git tests fail on `main` today.