### PR TITLE
Assets can be searched by name, and an empty folder can be thrown away

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1877,6 +1877,137 @@ ipcMain.handle('assets:mkdir', async (_e, { projectPath, parentRel, name }) => {
   return { ok: true };
 });
 
+// Deleting an asset.
+//
+// An image is only ever referenced from somewhere else, so unlike a page there
+// is nothing on screen to say whether removing it breaks anything. The scan
+// below answers that before the question is asked, matched on the FILE NAME
+// rather than the path: the same file is written `/hero.png` from public/,
+// `../assets/hero.png` from a component, and `~/assets/hero.png` through an
+// alias, and a path match would miss two of the three. Loose in the other
+// direction — a name that reads as a word matches prose — which is the right
+// way for a warning to be wrong.
+const relOf = (projectPath, abs) => path.relative(projectPath, abs).split(path.sep).join('/');
+
+const REF_EXT = /\.(astro|md|mdx|html|json|css|[jt]sx?)$/i;
+const REF_SKIP = new Set(['node_modules', 'dist', '.git', '.astro', 'release']);
+
+function filesReferencing(projectPath, names) {
+  if (!names.length) return [];
+  const hits = [];
+  const walk = (dir) => {
+    let items;
+    try {
+      items = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const item of items) {
+      if (REF_SKIP.has(item.name)) continue;
+      const abs = path.join(dir, item.name);
+      if (item.isDirectory()) {
+        walk(abs);
+        continue;
+      }
+      if (!REF_EXT.test(item.name)) continue;
+      let text;
+      try {
+        text = fs.readFileSync(abs, 'utf8');
+      } catch {
+        continue;
+      }
+      if (names.some((n) => text.includes(n))) hits.push(relOf(projectPath, abs));
+    }
+  };
+  walk(path.join(projectPath, 'src'));
+  return hits;
+}
+
+// Every media file at or under `rel` — one name for a file, the folder's whole
+// contents for a folder, so deleting a folder is checked as what it holds.
+function assetNamesUnder(abs) {
+  let stat;
+  try {
+    stat = fs.statSync(abs);
+  } catch {
+    return [];
+  }
+  if (!stat.isDirectory()) return [path.basename(abs)];
+  const names = [];
+  const walk = (dir) => {
+    let items;
+    try {
+      items = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const item of items) {
+      if (item.isDirectory()) walk(path.join(dir, item.name));
+      else names.push(item.name);
+    }
+  };
+  walk(abs);
+  return names;
+}
+
+ipcMain.handle('assets:usage', async (_e, { projectPath, rel }) => {
+  const abs = assetAbs(projectPath, rel);
+  return { files: filesReferencing(projectPath, assetNamesUnder(abs)) };
+});
+
+// Does this folder still hold a file, anywhere below it?
+//
+// Dotfiles are skipped the way the listing skips them. A folder holding
+// nothing but a .DS_Store reads as empty in the panel, and a refusal the panel
+// can't explain is worse than the stray file it is protecting.
+function holdsAnyFile(abs) {
+  let items;
+  try {
+    items = fs.readdirSync(abs, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const item of items) {
+    if (item.name.startsWith('.')) continue;
+    if (item.isDirectory()) {
+      if (holdsAnyFile(path.join(abs, item.name))) return true;
+    } else {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Trashed rather than unlinked: the panel's other destructive-looking actions
+// (rename, move) are all undoable, and a delete that only the Finder can undo
+// is still a delete you can undo.
+//
+// Two things it refuses outright. public/ and src/ are where an Astro project
+// keeps everything — removing one isn't an edit, it's the end of the project.
+// And a folder goes only when it is empty: one click that takes an unknown
+// number of files with it is the one delete no Trash makes comfortable, so the
+// files are deleted first and seen while they go.
+ipcMain.handle('assets:delete', async (_e, { projectPath, rel }) => {
+  const abs = assetAbs(projectPath, rel);
+  const clean = String(rel || '').replace(/^\/+/, '');
+  if (!clean.includes('/') || abs === path.resolve(projectPath, rootOfRel(clean))) {
+    throw new Error('public/ and src/ are part of the project itself — they can’t be deleted here.');
+  }
+  let stat;
+  try {
+    stat = fs.statSync(abs);
+  } catch {
+    throw new Error('That file is already gone.');
+  }
+  if (stat.isDirectory() && holdsAnyFile(abs)) {
+    throw new Error('That folder still has files in it. Delete those first, then the folder.');
+  }
+  markSelfWrite(abs);
+  await shell.trashItem(abs);
+  send('assets:changed', {});
+  return { ok: true };
+});
+
 // ---------------------------------------------------------------------------
 // CMS — JSON data files under src/ edited as collections
 // ---------------------------------------------------------------------------

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1262,6 +1262,8 @@ contextBridge.exposeInMainWorld('avb', {
   moveAsset: invoke('assets:move'),
   renameAsset: invoke('assets:rename'),
   mkdirAssets: invoke('assets:mkdir'),
+  assetUsage: invoke('assets:usage'),
+  deleteAsset: invoke('assets:delete'),
   readAssetText: invoke('assets:readText'),
   writeAssetText: invoke('assets:writeText'),
   // The source file an imported symbol is defined in — data files, consts,

--- a/src/panels/AssetsPanel.jsx
+++ b/src/panels/AssetsPanel.jsx
@@ -6,7 +6,9 @@ import {
   ChevronRightIcon,
   FileIcon,
   CodeIcon,
+  TrashIcon,
 } from '../ui/Icons.jsx';
+import { confirmDialog } from '../ui/ConfirmDialog.jsx';
 
 import AssetThumb, { TEXT_EXT } from '../ui/AssetThumb.jsx';
 
@@ -47,6 +49,7 @@ export default function AssetsPanel({ project, showToast, onOpenFile, pick, onPi
   const [renaming, setRenaming] = useState(null); // rel of entry being renamed
   const [newFolder, setNewFolder] = useState(false);
   const [dragTarget, setDragTarget] = useState(null); // folder rel or '' (cwd)
+  const [query, setQuery] = useState('');
   const cwdRef = useRef('');
   cwdRef.current = cwd;
 
@@ -99,10 +102,22 @@ export default function AssetsPanel({ project, showToast, onOpenFile, pick, onPi
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pickKey, entries]);
 
-  const folders = entries.filter((e) => e.isDir && e.parent === cwd);
+  // A search looks through the whole project, not the folder you happen to be
+  // standing in — the reason to type a file name is that you don't know where
+  // it lives. The breadcrumb stays put so leaving the search puts you back.
+  const q = query.trim().toLowerCase();
+  const matches = (e) => e.name.toLowerCase().includes(q) || e.rel.toLowerCase().includes(q);
+
+  const folders = entries.filter((e) => e.isDir && (q ? matches(e) : e.parent === cwd));
   const files = entries
-    .filter((e) => !e.isDir && e.parent === cwd)
+    .filter((e) => !e.isDir && (q ? matches(e) : e.parent === cwd))
     .filter((e) => !pick || kindMatches(pick.mediaKind, e.name));
+
+  // A folder goes only when it is empty, and public/ and src/ never go at all —
+  // the guard is in the handler, and this is the same rule said in the UI so
+  // the button is never offered for something that would be refused.
+  const holdsFiles = (folder) =>
+    entries.some((e) => !e.isDir && e.rel.startsWith(`${folder.rel}/`));
 
   const act = async (fn) => {
     try {
@@ -184,6 +199,46 @@ export default function AssetsPanel({ project, showToast, onOpenFile, pick, onPi
     });
   };
 
+  // --- Delete ----------------------------------------------------------
+
+  // Asked with the answer already in hand: the scan runs first so the question
+  // can name the pages that would lose the file, rather than asking whether
+  // the user happens to remember.
+  const askDelete = async (entry) => {
+    let used = [];
+    try {
+      const res = await window.avb.assetUsage({ projectPath: project.path, rel: entry.rel });
+      used = res?.files || [];
+    } catch {
+      // A scan that fails is not a reason to block the delete — the confirm
+      // just loses the extra sentence.
+    }
+    const ok = await confirmDialog({
+      title: `Delete ${entry.name}?`,
+      body: used.length ? (
+        <>
+          {entry.isDir ? 'This folder' : 'This file'} is named in{' '}
+          {used.length === 1 ? '1 file' : `${used.length} files`}:
+          <ul className="asset-usage">
+            {used.slice(0, 6).map((f) => (
+              <li key={f}>{f}</li>
+            ))}
+            {used.length > 6 && <li>…and {used.length - 6} more</li>}
+          </ul>
+          Deleting it will leave those references pointing at nothing.
+        </>
+      ) : entry.isDir ? (
+        'The folder is empty. It goes to the Trash, so you can put it back from there.'
+      ) : (
+        'It goes to the Trash, so you can put it back from there.'
+      ),
+      confirmLabel: 'Delete',
+      danger: true,
+    });
+    if (!ok) return;
+    act(() => window.avb.deleteAsset({ projectPath: project.path, rel: entry.rel }));
+  };
+
   // --- Breadcrumb ------------------------------------------------------
 
   // '' is above both roots now, so it can't be called "public".
@@ -252,6 +307,16 @@ export default function AssetsPanel({ project, showToast, onOpenFile, pick, onPi
             <UploadCloudIcon size={14} />
           </button>
         </div>
+      </div>
+
+      <div style={{ padding: '0 12px 8px' }}>
+        <input
+          value={query}
+          placeholder="Search assets"
+          spellCheck={false}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => e.key === 'Escape' && setQuery('')}
+        />
       </div>
 
       {pick && (
@@ -340,7 +405,27 @@ export default function AssetsPanel({ project, showToast, onOpenFile, pick, onPi
             {renaming === folder.rel ? (
               <RenameInput entry={folder} onCommit={commitRename} />
             ) : (
-              <span className="asset-folder-name">{folder.name}</span>
+              <span className="asset-folder-name">
+                {folder.name}
+                {q && folder.parent ? <span className="asset-where">{folder.parent}/</span> : null}
+              </span>
+            )}
+            {!pick && !folder.isRoot && (
+              <button
+                className="ghost asset-delete"
+                title={
+                  holdsFiles(folder)
+                    ? 'Delete the files inside it first'
+                    : `Delete ${folder.name}`
+                }
+                disabled={holdsFiles(folder)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  askDelete(folder);
+                }}
+              >
+                <TrashIcon size={12} />
+              </button>
             )}
             <span className="crumb-sep">
               <ChevronRightIcon size={9} />
@@ -373,18 +458,33 @@ export default function AssetsPanel({ project, showToast, onOpenFile, pick, onPi
               // files, whose thumb would otherwise open the code editor.
               onClick={pick ? () => pick.onPick(file.rel, file) : undefined}
             >
-              <AssetThumb
-                file={file}
-                className={editable && !pick ? 'editable' : ''}
-                onClick={() =>
-                  !pick && editable && onOpenFile?.({ rel: file.rel, name: file.name })
-                }
-              />
+              <div className="asset-thumb-wrap">
+                <AssetThumb
+                  file={file}
+                  className={editable && !pick ? 'editable' : ''}
+                  onClick={() =>
+                    !pick && editable && onOpenFile?.({ rel: file.rel, name: file.name })
+                  }
+                />
+                {!pick && (
+                  <button
+                    className="ghost asset-delete"
+                    title={`Delete ${file.name}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      askDelete(file);
+                    }}
+                  >
+                    <TrashIcon size={12} />
+                  </button>
+                )}
+              </div>
               {renaming === file.rel ? (
                 <RenameInput entry={file} onCommit={commitRename} />
               ) : (
                 <div className="asset-name" onDoubleClick={() => setRenaming(file.rel)}>
                   {file.name}
+                  {q && file.parent ? <div className="asset-where">{file.parent}/</div> : null}
                 </div>
               )}
             </div>
@@ -394,7 +494,9 @@ export default function AssetsPanel({ project, showToast, onOpenFile, pick, onPi
 
         {folders.length === 0 && files.length === 0 && !newFolder && (
           <div className="props-empty">
-            Empty folder. Drop files here or use the upload button.
+            {q
+              ? `No assets match “${query.trim()}”.`
+              : 'Empty folder. Drop files here or use the upload button.'}
           </div>
         )}
       </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -929,6 +929,49 @@ textarea { font-family: inherit; font-size: 12px; line-height: 1.5; resize: none
   pointer-events: none;
 }
 .asset-tile:hover .asset-badge { opacity: 0; }
+
+/* The folder a search result came from, since results span the whole project. */
+.asset-where {
+  color: var(--text-faint);
+  font-size: 10px;
+  font-weight: 400;
+  margin-left: 4px;
+}
+.asset-folder .asset-where { margin-left: 6px; }
+.asset-name .asset-where { margin-left: 0; }
+
+/* Delete stays out of the way until the pointer is on the thing it deletes —
+   a trash can sitting permanently on every tile reads as a busier panel than
+   this one is. */
+.asset-thumb-wrap { position: relative; }
+.asset-delete {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  padding: 3px;
+  border-radius: 5px;
+  opacity: 0;
+  background: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.9);
+}
+.asset-folder .asset-delete { position: static; opacity: 0; background: none; }
+.asset-tile:hover .asset-delete,
+.asset-folder:hover .asset-delete,
+.asset-delete:focus-visible { opacity: 1; }
+.asset-delete:hover { color: var(--red); }
+.asset-delete:disabled {
+  color: var(--text-faint);
+  cursor: default;
+}
+.asset-delete:disabled:hover { color: var(--text-faint); }
+
+/* The files a doomed asset is still named in. */
+.asset-usage {
+  margin: 6px 0;
+  padding-left: 16px;
+  color: var(--text-dim);
+}
+.asset-usage li { margin: 2px 0; }
 /* A folded-in HTML comment beside a node's name in the navigator. */
 .node-note {
   color: var(--text-faint);


### PR DESCRIPTION
Two small additions to the Assets panel, both filling gaps the Pages panel does not have.

### Search

The same field Pages has, with one deliberate difference: **it looks through the whole project, not the folder you are standing in.** The reason to type a file name is that you do not know where it lives. Each result says which folder it came from, the breadcrumb stays put so leaving the search puts you back, and Escape clears it.

### Delete

A trash button appears on a tile or a folder row under the pointer.

**It trashes rather than unlinks.** Every other destructive-looking action in the panel — rename, move — is undoable, and a delete you can recover from the Finder is still a delete you can undo.

**It asks with the answer already in hand.** `src/` is scanned before the question is put, and the confirm names the files that reference the asset. The match is on the **file name**, not the path: the same image is written `/hero.png` from `public/`, `../assets/hero.png` from a component, and `~/assets/hero.png` through an alias, so a path match would miss two of the three. Loose in the other direction — a name that reads as a word matches prose — which is the right way for a warning to be wrong.

**Two things it refuses.**

- `public/` and `src/` are the project itself. The button is not rendered for them (the entries already carry `isRoot`), and the handler refuses independently.
- A folder goes only when it is empty. One click that takes an unknown number of files with it is the one delete no Trash makes comfortable. The button greys out with *"Delete the files inside it first"*, and the rule is stated in both layers so the button is never offered for something that would be refused.

Hidden files are skipped in the emptiness check the way the listing skips them — otherwise a folder holding nothing but `.DS_Store` looks empty in the panel and refuses for a reason nothing on screen can explain.

### Note

While writing this I noticed text assets (`css`, `js`, `json`, `svg`) are *already* editable by clicking the thumbnail — it is just not discoverable, since nothing indicates the thumbnail is clickable. Left alone here; mentioning it in case it is worth a separate look.

### Verification

`vite build` clean. Full suite green, including `bridge` (which validates that the two new preload methods are both exposed and called).