### PR TITLE
Fix canvas selection: htmlText.js needs to be in asarUnpack too

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
       "node_modules/node-pty/**/*"
     ],
     "asarUnpack": [
-      "electron/astroParser.js",
+      "electron/**",
       "**/node_modules/node-pty/**"
     ],
     "npmRebuild": false,


### PR DESCRIPTION
Clicking in the canvas did nothing, no outlines or selection, plus full reloads and the Astro toolbar showing up.

astroParser.js is unpacked but htmlText.js isn't, and astroParser does require('./htmlText'). That require dies in the Astro process (no asar), the config never loads, and Astro falls back to a plain astro dev with no config.

Used electron/** instead of just htmlText.js so it won't happen again with the next required file.

Saw it on 0.1.16 and 0.1.17 (macOS).