### PR TITLE
Unpack every electron module the preview parser reaches for (fixes #14)

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -3332,6 +3332,31 @@ function parsesAsModule(file) {
   }
 }
 
+// A syntax check passes on a config that still cannot load: the generated
+// config requires the parser out of app.asar.unpacked, and if a sibling the
+// parser itself requires was left packed inside app.asar, that require throws
+// only at runtime — Astro fails to start and the preview silently drops to a
+// bare server with no markers (no outlines, no canvas selection). Loading the
+// parser the same way the dev server will catches that here instead. We load
+// only the parser — our own code, no load-time side effects — deliberately not
+// the generated config, whose `import userConfig` would pull in the project's
+// astro config (possibly TS or side-effectful) and could fail where Astro would
+// not, dropping a preview that would otherwise have worked.
+function requireLoads(file) {
+  try {
+    const bin = resolveNodeBin();
+    if (!bin) return true; // nothing to check with — let Astro have its say
+    const out = spawnSync(bin, ['-e', `require(${JSON.stringify(file)})`], {
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+    if (out.error || out.status === null) return true; // check could not run
+    return out.status === 0;
+  } catch {
+    return true;
+  }
+}
+
 function writeMarkerConfig(projectPath) {
   try {
     const dir = path.join(projectPath, 'node_modules', '.avb');
@@ -3665,9 +3690,9 @@ export default {
     // will and say no rather than hand over something that cannot load: the
     // caller falls back to a plain dev server, which costs the outlines and
     // the live patching and keeps everything else working.
-    if (!parsesAsModule(cfgPath)) {
+    if (!parsesAsModule(cfgPath) || !requireLoads(parserPath)) {
       pushDevLog(
-        '\n[stacki] the generated preview config did not parse; starting the dev ' +
+        '\n[stacki] the generated preview config could not be loaded; starting the dev ' +
           'server without it. Outlines and live updates are off for this session.\n'
       );
       return null;

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
       "node_modules/node-pty/**/*"
     ],
     "asarUnpack": [
-      "electron/astroParser.js",
+      "electron/**",
       "**/node_modules/node-pty/**"
     ],
     "npmRebuild": false,


### PR DESCRIPTION
## Problem

Fixes #14 — since 0.1.15 (Aug 23), clicking elements on the canvas does nothing (behaves like Preview mode). Navigator selection still works but nothing highlights on the canvas.

## Root cause

A packaging bug, not a canvas/socket issue. Canvas selection depends on markers injected via a generated Astro dev config, which runs in a plain Node child process and:

- rewrites the parser path to `app.asar.unpacked/electron/astroParser.js` and `require()`s it (`electron/main.js`),
- and the parser itself does `require('./htmlText')` (`electron/astroParser.js:18`).

Only `astroParser.js` was listed in `build.asarUnpack`, so `htmlText.js` stayed **inside** `app.asar`. The relative require resolved beside the unpacked parser (`app.asar.unpacked/electron/htmlText.js`), found nothing, and threw **at runtime** → the config import failed → Astro fell back to a bare dev server with **no marker injection** → no canvas outlines and no click-to-select. Navigator selection uses editor state, so it still selects but has nothing on the canvas to highlight. (Same config drop also explains the reported full reloads and the Astro dev toolbar appearing.)

`htmlText.js` was split out of the parser on Aug 21 and the unpack list never followed; it first shipped in 0.1.15 on Aug 23. Dev builds are unaffected (no asar in the path), which is why it wasn't caught locally.

Credit to the detailed community diagnosis on the issue thread.

## Fix

1. **`package.json`** — unpack `electron/**` instead of just `electron/astroParser.js`, so the next sibling module the parser reaches for won't reintroduce this.
2. **`electron/main.js`** — the existing `parsesAsModule()` guard only runs `node --check` (a syntax pass), which passes on a config that fails at runtime. Added a `requireLoads()` probe that actually loads the parser the way the dev server will, before handing the config to Astro. The probe loads **only** the parser (our own code, no load-time side effects) — deliberately not the generated config, whose `import userConfig` would pull in the project's astro config (possibly TS or side-effectful) and could fail where Astro would not, dropping a preview that would otherwise work.

## Verification

- `node --check` passes on both edited files; `package.json` is valid JSON.
- Simulated the probe both ways: parser **with** `htmlText.js` beside it → loads (config kept); **without** it (the broken packaging) → probe returns false (clean fallback with a clear dev-log message).
- Ran the tests covering the touched paths (`canvas-click`, `outlines`, `markers`, `slot-markers`, `preview-recovery`, `content-config`) — all pass. `preview-worktree.js` fails 3/25 but fails **identically on a clean tree** (pre-existing, unrelated), so this change introduces no regression.


