### PR TITLE
Fix round-trip test gate running zero tests on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "scripts": {
     "roundtrip:report": "node scripts/roundtrip-report.js",
-    "test:roundtrip": "node --test 'test/*.test.js'",
+    "test:roundtrip": "node --test test/*.test.js",
     "postinstall": "node scripts/fix-node-pty-permissions.js",
     "dev": "concurrently -k \"vite\" \"wait-on tcp:5173 && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 node scripts/dev-electron.mjs\"",
     "build": "vite build",


### PR DESCRIPTION
## The problem

`npm run test:roundtrip` on Windows silently runs **zero tests and exits 0**.

The script is `node --test 'test/*.test.js'`. npm scripts on Windows run under cmd, where single quotes are literal characters rather than shell quoting — so the pattern matches no files:

```
$ npm run test:roundtrip
1..0
# tests 0
# fail 0        ← exit code 0
```

A Windows contributor gets a false green from the project's central safety property.

## The fix

Drop the quotes: `node --test test/*.test.js`. POSIX shells expand the glob themselves, and on Windows Node's test runner (≥21) glob-expands the literal argument, so the gate runs its 161 tests on every platform.

Pointing `--test` at the `test/` directory instead would not work — Node's directory-mode matcher would sweep in the plain `.js` harness scripts that live alongside the two `*.test.js` files.

## Verified on Windows

After the change, `npm run test:roundtrip` runs 161 tests (142 pass, 18 fail, npm exits 1). The 18 failures are the known CRLF round-trip collateral — now visible instead of masked.