### PR TITLE
Pin test/corpus line endings so the round-trip gate measures the parser, not git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/corpus/** -text


### PR DESCRIPTION
## The problem

There is no `.gitattributes`, so the round-trip corpus is checked out with whatever line endings the client's git config produces. On a Windows clone with `core.autocrlf=true` (the common default), every fixture in `test/corpus/` is stored LF in the repository but lands CRLF in the working tree.

A gate whose entire premise is byte-for-byte identity cannot let the version control system rewrite its own inputs: on such a clone the suite reports 18 failures out of 26 fixtures — a measurement of git's configuration, not of the parser.

## The fix

One line:

```
test/corpus/** -text
```

`-text` disables all end-of-line conversion for the corpus, so checkout is byte-exact on every platform and every autocrlf setting.

Verified on a Windows machine with `core.autocrlf=true`:

- After re-checkout, `git ls-files --eol` shows all 26 fixtures at `w/lf` with the `-text` attribute applied — byte-identical to what's stored.
- `node --test test/roundtrip.test.js` goes from 18 failures to **130 pass, 0 fail**. Every failure was git rewriting the fixtures, not the parser.

## Note for existing Windows clones

Git does not rewrite files it considers unchanged, so already-cloned working trees keep their CRLF copies until refreshed:

```
rm test/corpus/*.astro
git checkout -- test/corpus/
```

(or a fresh clone.)

This is also the prerequisite for adding any deliberately-CRLF fixture to the corpus — without the pin, git may transparently rewrite it on checkout.